### PR TITLE
Fix(particles): Refine task cancellation in ParticleManager

### DIFF
--- a/src/main/java/com/jerae/zephaire/particles/managers/ParticleManager.java
+++ b/src/main/java/com/jerae/zephaire/particles/managers/ParticleManager.java
@@ -38,7 +38,16 @@ public class ParticleManager {
                 animationManager.cancel();
             } catch (IllegalStateException ignored) {}
         }
-        plugin.getServer().getScheduler().cancelTasks(plugin);
+        // Cancel all active particle tasks, which are self-contained BukkitRunnables.
+        for (Debuggable particle : new ArrayList<>(activeParticles.values())) {
+            if (particle instanceof BukkitRunnable) {
+                try {
+                    if (!((BukkitRunnable) particle).isCancelled()) {
+                        ((BukkitRunnable) particle).cancel();
+                    }
+                } catch (IllegalStateException ignored) {}
+            }
+        }
 
         particleNames.clear();
         activeParticles.clear();


### PR DESCRIPTION
The `initialize` method in `ParticleManager` was previously cancelling all plugin tasks using `plugin.getServer().getScheduler().cancelTasks(plugin)`. This was overly broad and could cause unintended side effects by cancelling unrelated tasks scheduled by other parts of the plugin.

This commit refactors the task cancellation logic to be more precise. Instead of a blanket cancellation, the method now iterates through the `activeParticles` map and cancels only the `BukkitRunnable` tasks that it is directly responsible for (i.e., static particle tasks).

This change improves the stability and predictability of the plugin's reload mechanism without affecting its intended behavior.